### PR TITLE
Ajout de la fonctionnalité de statut pour les todos

### DIFF
--- a/exercice.py
+++ b/exercice.py
@@ -1,0 +1,40 @@
+# Liste des todos
+todos = []
+
+# Fonction pour lister les todos
+def lister_todos():
+    """Lister les todos existants."""
+    if not todos:
+        print('Aucun todo disponible.')
+    else:
+        print('\n==== Liste des todos ====')
+        for i, todo in enumerate(todos, start=1):
+            print(f'{i}. {todo["titre"]}')
+        print('=========================')
+
+# Fonction pour créer un todo
+def creer_todo():
+    """Créer un todo."""
+    titre = input('Entrez le titre du todo : ')
+    todos.append({'titre': titre})
+    print(f'Todo "{titre}" ajouté avec succès !')
+
+# Menu principal
+choix = ''
+while choix != 'q':
+    print('\n==== Menu principal ====')
+    print('1: Lister les todos')
+    print('2: Créer un todo')
+    print('q: Quitter')
+    print('=========================')
+
+    choix = input('=> Choix : ')
+
+    if choix == '1':
+        lister_todos()
+    elif choix == '2':
+        creer_todo()
+    elif choix == 'q':
+        print('Au revoir !')
+    else:
+        print('Choix incorrect.')

--- a/exercice.py
+++ b/exercice.py
@@ -35,9 +35,31 @@ def modifier_statut_todo():
                 todo['statut'] = 'Fait'
                 print(f'Le statut du todo "{todo["titre"]}" est maintenant "Fait".')
             elif todo['statut'] == 'Fait':
-                # Erreur volontaire : met le statut en "À fair" sans le "e"
-                todo['statut'] = 'À fair'
-                print(f'Le statut du todo "{todo["titre"]}" est maintenant "À fair".')
+                todo['statut'] = 'À faire'  # Correction de l'erreur volontaire
+                print(f'Le statut du todo "{todo["titre"]}" est maintenant "À faire".')
+        else:
+            print('Numéro de todo invalide.')
+    except ValueError:
+        print('Veuillez entrer un numéro valide.')
+
+# Fonction pour supprimer un todo
+def supprimer_todo():
+    """Supprimer un todo."""
+    if not todos:
+        print('Aucun todo disponible pour suppression.')
+        return
+
+    lister_todos()
+    try:
+        choix = int(input('Entrez le numéro du todo à supprimer : '))
+        if 1 <= choix <= len(todos):
+            todo = todos[choix - 1]
+            confirmation = input(f'Êtes-vous sûr de vouloir supprimer "{todo["titre"]}" ? (o/n) : ')
+            if confirmation.lower() == 'o':
+                todos.pop(choix - 1)
+                print(f'Todo "{todo["titre"]}" supprimé avec succès.')
+            else:
+                print('Suppression annulée.')
         else:
             print('Numéro de todo invalide.')
     except ValueError:
@@ -50,6 +72,7 @@ while choix != 'q':
     print('1: Lister les todos')
     print('2: Créer un todo')
     print('3: Modifier le statut d\'un todo')
+    print('4: Supprimer un todo')
     print('q: Quitter')
     print('=========================')
 
@@ -61,9 +84,13 @@ while choix != 'q':
         creer_todo()
     elif choix == '3':
         modifier_statut_todo()
+    elif choix == '4':
+        supprimer_todo()
     elif choix == 'q':
         print('Au revoir !')
     else:
         print('Choix invalide.')
+
+   
 
 

--- a/exercice.py
+++ b/exercice.py
@@ -3,21 +3,45 @@ todos = []
 
 # Fonction pour lister les todos
 def lister_todos():
-    """Lister les todos existants."""
+    """Lister les todos existants avec leur statut."""
     if not todos:
         print('Aucun todo disponible.')
     else:
         print('\n==== Liste des todos ====')
         for i, todo in enumerate(todos, start=1):
-            print(f'{i}. {todo["titre"]}')
+            print(f'{i}. {todo["titre"]} - Statut : {todo["statut"]}')
         print('=========================')
 
 # Fonction pour créer un todo
 def creer_todo():
     """Créer un todo."""
     titre = input('Entrez le titre du todo : ')
-    todos.append({'titre': titre})
-    print(f'Todo "{titre}" ajouté avec succès !')
+    todos.append({'titre': titre, 'statut': 'À faire'})  # Ajoute le statut "À faire" par défaut
+    print(f'Todo "{titre}" ajouté avec succès avec le statut "À faire" !')
+
+# Fonction pour modifier le statut d'un todo
+def modifier_statut_todo():
+    """Modifier le statut d'un todo."""
+    if not todos:
+        print('Aucun todo disponible pour modification.')
+        return
+
+    lister_todos()
+    try:
+        choix = int(input('Entrez le numéro du todo à modifier : '))
+        if 1 <= choix <= len(todos):
+            todo = todos[choix - 1]
+            if todo['statut'] == 'À faire':
+                todo['statut'] = 'Fait'
+                print(f'Le statut du todo "{todo["titre"]}" est maintenant "Fait".')
+            elif todo['statut'] == 'Fait':
+                # Erreur volontaire : met le statut en "À fair" sans le "e"
+                todo['statut'] = 'À fair'
+                print(f'Le statut du todo "{todo["titre"]}" est maintenant "À fair".')
+        else:
+            print('Numéro de todo invalide.')
+    except ValueError:
+        print('Veuillez entrer un numéro valide.')
 
 # Menu principal
 choix = ''
@@ -25,6 +49,7 @@ while choix != 'q':
     print('\n==== Menu principal ====')
     print('1: Lister les todos')
     print('2: Créer un todo')
+    print('3: Modifier le statut d\'un todo')
     print('q: Quitter')
     print('=========================')
 
@@ -34,7 +59,11 @@ while choix != 'q':
         lister_todos()
     elif choix == '2':
         creer_todo()
+    elif choix == '3':
+        modifier_statut_todo()
     elif choix == 'q':
         print('Au revoir !')
     else:
-        print('Choix incorrect.')
+        print('Choix invalide.')
+
+


### PR DESCRIPTION
Cette Pull Request introduit la fonctionnalité permettant d'ajouter un statut aux todos. Chaque todo peut maintenant être marqué avec l'un des statuts suivants :

À faire : Statut par défaut lors de la création d'un todo.
Fait : Statut modifiable par l'utilisateur lorsque la tâche est terminée.
De plus, une fonctionnalité est ajoutée pour permettre à l'utilisateur de changer le statut d'un todo entre "À faire" et "Fait". Si un todo est déjà "À faire", il peut être mis à jour en "Fait". Si un todo est "Fait", il peut être repassé en "À faire".

Un comportement erroné est introduit volontairement dans la logique de modification du statut : lorsque l'on tente de repasser un todo de "Fait" à "À faire", le statut est modifié en "À fair" (sans le "e" final), ce qui provoque un bug intentionnel pour tester le processus de correction.